### PR TITLE
Feature/add vio

### DIFF
--- a/robot_description/config/ackermann_controller.yaml
+++ b/robot_description/config/ackermann_controller.yaml
@@ -61,8 +61,8 @@ ackermann_steering_controller:
     publish_odom_tf: false
     
     # cmd_vel_topic: /ackmann/cmd_vel
-    odom_topic: /encoder/odom
-    tf_topic: /ackmann/tf
+    odom_topic: /wheel/odom
+    tf_topic: /tf
     odom_frame_id: odom
     base_frame_id: ackmann/base_footprint
     

--- a/robot_description/config/ackermann_controller.yaml
+++ b/robot_description/config/ackermann_controller.yaml
@@ -60,9 +60,10 @@ ackermann_steering_controller:
     publish_odom: true
     publish_odom_tf: false
     
+    # topic name only works in urdf
     # cmd_vel_topic: /ackmann/cmd_vel
-    odom_topic: /wheel/odom
-    tf_topic: /tf
+    #odom_topic: /wheel/odom
+    #tf_topic: /tf
     odom_frame_id: odom
     base_frame_id: ackmann/base_footprint
     

--- a/robot_description/config/nav2_params.yaml
+++ b/robot_description/config/nav2_params.yaml
@@ -3,7 +3,8 @@ bt_navigator:
     use_sim_time: True
     global_frame: map
     robot_base_frame: ackmann/base_footprint
-    odom_topic: ackmann/odom
+    odom_topic: /vo_odom
+    odom_frame_id: odom
     bt_loop_duration: 10
     default_server_timeout: 20
     # 'default_nav_through_poses_bt_xml' and 'default_nav_to_pose_bt_xml' are use defaults:
@@ -69,6 +70,7 @@ bt_navigator_navigate_to_pose_rclcpp_node:
 controller_server:
   ros__parameters:
     use_sim_time: True
+    odom_topic: "/vo_odom"
     controller_frequency: 20.0
     min_x_velocity_threshold: 0.001
     min_y_velocity_threshold: 0.5
@@ -142,7 +144,7 @@ local_costmap:
     ros__parameters:
       update_frequency: 5.0
       publish_frequency: 2.0
-      global_frame: ackmann/odom
+      global_frame: odom
       robot_base_frame: ackmann/base_footprint
       use_sim_time: True
       rolling_window: true
@@ -252,7 +254,7 @@ behavior_server:
       plugin: "nav2_behaviors/Wait"
     assisted_teleop:
       plugin: "nav2_behaviors/AssistedTeleop"
-    global_frame: ackmann/odom
+    global_frame: odom
     robot_base_frame: ackmann/base_footprint
     transform_tolerance: 0.1
     use_sim_time: true
@@ -286,7 +288,7 @@ velocity_smoother:
     min_velocity: [-0.26, 0.0, -1.0]
     max_accel: [2.5, 0.0, 3.2]
     max_decel: [-2.5, 0.0, -3.2]
-    odom_topic: "ackmann/odom"
+    odom_topic: "/vo_odom"
     odom_duration: 0.1
     deadband_velocity: [0.0, 0.0, 0.0]
     velocity_timeout: 1.0

--- a/robot_description/config/nav2_params.yaml
+++ b/robot_description/config/nav2_params.yaml
@@ -3,7 +3,7 @@ bt_navigator:
     use_sim_time: True
     global_frame: map
     robot_base_frame: ackmann/base_footprint
-    odom_topic: /vo_odom
+    odom_topic: /odometry/filtered
     odom_frame_id: odom
     bt_loop_duration: 10
     default_server_timeout: 20
@@ -70,7 +70,7 @@ bt_navigator_navigate_to_pose_rclcpp_node:
 controller_server:
   ros__parameters:
     use_sim_time: True
-    odom_topic: "/vo_odom"
+    odom_topic: "/odometry/filtered"
     controller_frequency: 20.0
     min_x_velocity_threshold: 0.001
     min_y_velocity_threshold: 0.5
@@ -288,7 +288,7 @@ velocity_smoother:
     min_velocity: [-0.26, 0.0, -1.0]
     max_accel: [2.5, 0.0, 3.2]
     max_decel: [-2.5, 0.0, -3.2]
-    odom_topic: "/vo_odom"
+    odom_topic: "/odometry/filtered"
     odom_duration: 0.1
     deadband_velocity: [0.0, 0.0, 0.0]
     velocity_timeout: 1.0

--- a/robot_description/launch/ackmann_ign.launch.py
+++ b/robot_description/launch/ackmann_ign.launch.py
@@ -162,7 +162,7 @@ def generate_launch_description():
             '/ackmann/depth_camera/points' + '@sensor_msgs/msg/PointCloud2' + '[ignition.msgs.PointCloudPacked',
             '/ackmann/depth_camera/depth_image' + '@sensor_msgs/msg/Image' + '[ignition.msgs.Image',
             '/ackmann/depth_camera/image' + '@sensor_msgs/msg/Image' + '[ignition.msgs.Image',
-            '/ackmann/odom' + '@nav_msgs/msg/Odometry' + '[ignition.msgs.Odometry',
+            #'/ackmann/odom' + '@nav_msgs/msg/Odometry' + '[ignition.msgs.Odometry',
             '/ackmann/tf' + '@tf2_msgs/msg/TFMessage' + '[ignition.msgs.Pose_V',
             '/model/ackmann/tf' + '@tf2_msgs/msg/TFMessage' + '[ignition.msgs.Pose_V',
             #'/ackmann/joint_state' + '@sensor_msgs/msg/JointState' + '[ignition.msgs.Model',
@@ -178,7 +178,7 @@ def generate_launch_description():
         output='screen',
         remappings=[ 
             ('/ackmann/tf', '/tf'),
-            ('/ackmann/odom', '/odom'),
+            #('/ackmann/odom', '/odom'),
             #('/world/warehouse/model/ackmann/joint_state', '/joint_states'),
         ]
     ) 
@@ -332,7 +332,7 @@ def generate_launch_description():
     ld.add_action(topic_bridge)
     ld.add_action(gz_spawn_entity)
     ld.add_action(scan_clipper_node)
-    ld.add_action(imu_covariance_injector)
+    #ld.add_action(imu_covariance_injector)
     ld.add_action(ros2_controller_callback)
     #ld.add_action(localization)
     #ld.add_action(slam)

--- a/robot_description/launch/ackmann_ign.launch.py
+++ b/robot_description/launch/ackmann_ign.launch.py
@@ -336,6 +336,6 @@ def generate_launch_description():
     ld.add_action(ros2_controller_callback)
     #ld.add_action(localization)
     #ld.add_action(slam)
-    #ld.add_action(nav2)
+    ld.add_action(nav2)
     ld.add_action(rviz)
     return ld

--- a/robot_description/launch/rtabmap_odom.launch.py
+++ b/robot_description/launch/rtabmap_odom.launch.py
@@ -232,6 +232,7 @@ def generate_launch_description():
             executable='ekf_node',
             name='ekf_filter_node',
             output='screen',
+
             parameters=[#os.path.join(pkg_robot_ignition_bringup, 'config', 'ekf.yaml'),
                 {"frequency": 30.0,
                  "predict_to_current_time": True,
@@ -240,6 +241,7 @@ def generate_launch_description():
                  "transform_timeout": 0.2,  
                  "publish_tf": True,
                  "two_d_mode": True,  # CRITICAL: Enable 2D mode
+                 "use_sim_time": LaunchConfiguration('use_sim_time'),
                  "map_frame": "map",                # Defaults to "map" if unspecified
                  "odom_frame": "odom",              # Defaults to "odom" if unspecified
                  "base_link_frame": "ackmann/base_footprint",  # Defaults to "base_link" if unspecified
@@ -289,12 +291,29 @@ def generate_launch_description():
             remappings=remappings)
     
     slam_node = Node(
-            package='rtabmap_slam', 
-            executable='rtabmap', 
-            output='screen',
-            parameters=parameters,
-            remappings=remappings,
-            arguments=['-d'])
+        package='rtabmap_slam', 
+        executable='rtabmap', 
+        output='screen',
+        parameters=parameters + [
+            {'frame_id': 'ackmann/base_footprint'},
+            {'odom_frame': 'odom'},
+            {'base_frame': 'ackmann/base_footprint'},
+            {'map_frame': 'map'},
+            {'use_sim_time': LaunchConfiguration('use_sim_time')},
+            {'publish_tf': True},
+            {'publish_map_tf': True},
+            {'publish_odom_tf': False},
+            {'wait_for_transform': 0.2},
+            {'wait_for_odom_to_init': True},
+            {'approx_sync': True},
+            {'approx_sync_max_interval': 0.05},
+            {'localization': LaunchConfiguration('localization')}
+            # Add more parameters as needed
+        ],
+        remappings=remappings + [
+            ('odom', '/odometry/filtered'),
+        ],
+        arguments=['-d'])
     # Open RViz
     rviz = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([rviz_launch]),
@@ -317,7 +336,7 @@ def generate_launch_description():
     #ld.add_action(imu_filter_node)
     ld.add_action(vio_node)
     ld.add_action(ekf_filter_node)
-    #ld.add_action(slam_node)
+    ld.add_action(slam_node)
     ld.add_action(ros2_controller_callback)
     ld.add_action(rviz)
     return ld

--- a/robot_description/launch/rtabmap_odom.launch.py
+++ b/robot_description/launch/rtabmap_odom.launch.py
@@ -260,16 +260,18 @@ def generate_launch_description():
                  #"odom0_twist_noise": [0.01, 0.01, 0.01, 0.01, 0.01, 0.01],
                  "imu0": "l515/imu/raw",
                  "imu0_config": [False, False, False,    # position (disable all)
-                                 False, False, False,      # orientation (only yaw)
+                                 False, False, True,      # orientation (only yaw)
                                  False, False, False,     # linear velocity (disable all)
-                                 True, True, True,      # angular velocity (only yaw)
-                                 True, True, True],      # linear acceleration (x, y only)
+                                 False, False, True,      # angular velocity (only yaw)
+                                 True, True, False],      # linear acceleration (x, y only)
                  "imu0_queue_size": 10,
                  "imu0_nodelay": False,
                  "imu0_differential": False,
                  "imu0_relative": True,  # Important for IMU
                  "imu0_remove_gravitational_acceleration": True,
-                 "imu0_noise": [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]  # Higher noise for IMU
+                 "imu0_noise": [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1],  # Higher noise for IMU
+                 "angular_velocity_covariance": [0.01, 0, 0, 0, 0.01, 0, 0, 0, 0.01],
+                 "linear_acceleration_covariance": [0.1, 0, 0, 0, 0.1, 0, 0, 0, 0.1],
                 }])
            
     # Compute quaternion of the IMU
@@ -336,7 +338,7 @@ def generate_launch_description():
     #ld.add_action(imu_filter_node)
     ld.add_action(vio_node)
     ld.add_action(ekf_filter_node)
-    ld.add_action(slam_node)
+    #ld.add_action(slam_node)
     ld.add_action(ros2_controller_callback)
     ld.add_action(rviz)
     return ld

--- a/robot_description/launch/rtabmap_odom.launch.py
+++ b/robot_description/launch/rtabmap_odom.launch.py
@@ -210,18 +210,35 @@ def generate_launch_description():
         actions=[ros2_controller_callback]
     )
     parameters=[{
-          'frame_id':'ackmann/base_footprint',
+          'frame_id': 'ackmann/base_footprint',
+          'odom_frame': 'odom',
+          'base_frame': 'ackmann/base_footprint',
+          'map_frame': 'map',
           'publish_tf': False,
           'subscribe_depth':True,
           #'subscribe_odom_info':True,
           'approx_sync':True,
           'approx_sync_max_interval': 0.05,
-          #'wait_imu_to_init': True,
-          'use_sim_time': True,
-          }]
+          'wait_imu_to_init': True,
+          'wait_for_transform': 0.2,
+          'wait_for_odom_to_init': True,
+          'use_sim_time': LaunchConfiguration('use_sim_time'),
+          # RTAB-Map's parameters should be strings:
+          'Mem/NotLinkedNodesKept':'false',
+          'Grid/MaxGroundHeight': '0.1',        # Maximum height of ground points
+          'Grid/MaxObstacleHeight': '0.8',      # Maximum height of obstacle points
+          'Grid/NormalsSegmentation': 'true',   # Enable normals segmentation
+          'Grid/RangeMax': '20',                # Maximum range for point cloud processing
+          'Grid/3D': 'false',                   # Use 2D grid for navigation
+          'Grid/RayTracing': 'true',            # Enable ray tracing for better obstacle detection
+          'Reg/Strategy':'1',                   # Use 3D->2D visual odometry
+          'Reg/Force3DoF':'true',               # Force 3 DoF for 2D navigation
+          'Mem/NotLinkedNodesKept':'false',     # Do not keep not linked nodes
+          }
+    ]
 
     remappings=[
-          ('imu', 'l515/imu/raw'),
+          ('imu', '/imu/data'),#'/l515/imu/raw' '/imu/data'
           ('rgb/image', '/ackmann/depth_camera/image'),
           ('rgb/camera_info', '/ackmann/depth_camera/camera_info'),
           ('depth/image', '/ackmann/depth_camera/depth_image'),
@@ -258,27 +275,57 @@ def generate_launch_description():
                  "odom0_relative": True,
                  #"odom0_pose_noise": [0.01, 0.01, 0.01, 0.01, 0.01, 0.01],  # Lower noise for odometry
                  #"odom0_twist_noise": [0.01, 0.01, 0.01, 0.01, 0.01, 0.01],
-                 "imu0": "l515/imu/raw",
+                 "imu0": "imu/data", #"/l515/imu/raw",
                  "imu0_config": [False, False, False,    # position (disable all)
                                  False, False, True,      # orientation (only yaw)
                                  False, False, False,     # linear velocity (disable all)
                                  False, False, True,      # angular velocity (only yaw)
-                                 True, True, False],      # linear acceleration (x, y only)
+                                 False, False, False],      # linear acceleration (x, y only)
                  "imu0_queue_size": 10,
                  "imu0_nodelay": False,
                  "imu0_differential": False,
                  "imu0_relative": True,  # Important for IMU
                  "imu0_remove_gravitational_acceleration": True,
-                 "imu0_noise": [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1],  # Higher noise for IMU
-                 "angular_velocity_covariance": [0.01, 0, 0, 0, 0.01, 0, 0, 0, 0.01],
-                 "linear_acceleration_covariance": [0.1, 0, 0, 0, 0.1, 0, 0, 0, 0.1],
-                }])
+                 # Process noise covariance (conservative values)
+                 "process_noise_covariance": [0.05, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0.05, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0.06, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0.03, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0.03, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0.06, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0.025, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0.025, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0.04, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0.01, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.01, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.02, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.01, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.01, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.015],
+                 # Initial estimate covariance (diagonal matrix)
+                 "initial_estimate_covariance": [1e-9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 1e-9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 1e-9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 1e-9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 1e-9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 1e-9, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 1e-9, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 1e-9, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 1e-9, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 1e-9, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1e-9, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1e-9, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1e-9, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1e-9, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1e-9]
+                            }]
+    )
            
     # Compute quaternion of the IMU
     imu_filter_node = Node(
             package='imu_filter_madgwick', executable='imu_filter_madgwick_node', output='screen',
             parameters=[{'use_mag': False, 
-                         'world_frame':'nwu', # ned, enu, nwu
+                         'world_frame':'enu', # ned, enu, nwu
                          #'yaw_offset': -1.5708,
                          'publish_tf':False,
                          #'fixed_frame': "camera_link"
@@ -289,7 +336,16 @@ def generate_launch_description():
             package='rtabmap_odom', 
             executable='rgbd_odometry', 
             output='screen',
-            parameters=parameters,
+            parameters=parameters + [
+                {'Odom/Strategy': '0'},             # Frame-to-Map visual odometry
+                {'Vis/MinInliers': '10'},           # Minimum inliers for robust matching
+                {'Vis/FeatureType': '6'},           # ORB features (6), robust for visual odometry
+                {'Vis/MaxFeatures': '1000'},        # Max features to detect
+                {'Vis/EstimationType': '1'},        # 3D->2D (PnP) for 2D navigation
+                {'Vis/MaxDepth': '20.0'},           # Max depth for point cloud
+                {'Odom/GuessMotion': 'true'},       # Use motion model for better initial guess
+                {'Odom/GuessSmoothingDelay': '0.1'},# Smoothing delay for guess motion
+            ],
             remappings=remappings)
     
     slam_node = Node(
@@ -297,18 +353,9 @@ def generate_launch_description():
         executable='rtabmap', 
         output='screen',
         parameters=parameters + [
-            {'frame_id': 'ackmann/base_footprint'},
-            {'odom_frame': 'odom'},
-            {'base_frame': 'ackmann/base_footprint'},
-            {'map_frame': 'map'},
-            {'use_sim_time': LaunchConfiguration('use_sim_time')},
             {'publish_tf': True},
             {'publish_map_tf': True},
-            {'publish_odom_tf': False},
-            {'wait_for_transform': 0.2},
-            {'wait_for_odom_to_init': True},
-            {'approx_sync': True},
-            {'approx_sync_max_interval': 0.05},
+            #{'publish_odom_tf': True},
             {'localization': LaunchConfiguration('localization')}
             # Add more parameters as needed
         ],
@@ -335,10 +382,10 @@ def generate_launch_description():
     ld.add_action(topic_bridge)
     ld.add_action(gz_spawn_entity)
     #ld.add_action(delayed_controller_spawning)  # Add delay
-    #ld.add_action(imu_filter_node)
+    ld.add_action(imu_filter_node)
     ld.add_action(vio_node)
     ld.add_action(ekf_filter_node)
-    #ld.add_action(slam_node)
+    ld.add_action(slam_node)
     ld.add_action(ros2_controller_callback)
     ld.add_action(rviz)
     return ld

--- a/robot_description/launch/rtabmap_slam.launch.py
+++ b/robot_description/launch/rtabmap_slam.launch.py
@@ -110,76 +110,6 @@ def generate_launch_description():
         package='rtabmap_sync', executable='rgbd_sync', output='screen',
         parameters=[{'approx_sync':False, 'use_sim_time':use_sim_time}],
         remappings=remappings)
-
-    # EKF filter node for localization
-    # This node uses the Extended Kalman Filter to fuse odometry and IMU data.
-    # It publishes the estimated pose to the /odom topic.
-    # It is used to provide a more accurate pose estimate for the robot.
-    # It is a part of the robot_localization package.
-    pkg = get_package_share_directory('robot_description')
-    control_params_file = PathJoinSubstitution([pkg, 'config', 'ekf.yaml'])
-    ekf_filter_node = Node(
-            package='robot_localization',
-            executable='ekf_node',
-            name='ekf_filter_node',
-            output='screen',
-            parameters=[control_params_file,
-                {"frequency": 30.0,
-                 "predict_to_current_time": True,
-                 "use_sim_time": use_sim_time,
-                 "two_d_mode": True,  # Often helpful for ground robots
-                 "publish_tf": True,
-                 "map_frame": "map",                # Defaults to "map" if unspecified
-                 "odom_frame": "odom",           # Defaults to "odom" if unspecified
-                 "base_link_frame": "ackmann/base_footprint",    # Defaults to "base_link" if unspecified
-                 "world_frame": "odom",             # Defaults to the value of odom_frame if unspecified
-                 
-                 # Additional stability parameters
-                "sensor_timeout": 0.2,  # Wait for sensor data
-                "transform_timeout": 0.1,
-                "transform_time_offset": 0.0,
-
-                 "odom0": "/vo_odom",
-                 "odom0_config": [True, True, False,    # x, y, z position
-                                  False, False, True,     # roll, pitch, yaw
-                                  True, True, False,     # x, y, z velocity
-                                  False, False, True,     # roll, pitch, yaw rates
-                                  False, False, False], # x, y, z acceleration
-                 "odom0_queue_size": 10,
-                 "odom0_nodelay": False,
-                 "odom0_differential": False,
-                 "odom0_relative": True,
-                 "odom0_pose_noise": [0.01, 0.01, 0.01, 0.01, 0.01, 0.01],  # Lower noise for odometry
-                 "odom0_twist_noise": [0.01, 0.01, 0.01, 0.01, 0.01, 0.01],
-                 
-                 # IMU Configuration  
-                "imu0": "/imu/data", #"/l515/imu/data",
-                "imu0_config": [False, False, False,   # x, y, z position
-                                False,  False,  True,    # roll, pitch, yaw
-                                False, False, False,   # x, y, z velocity
-                                False,  False,  True,    # roll, pitch, yaw rates
-                                False,  False,  False],   # x, y, z acceleration
-                 "imu0_queue_size": 10,
-                 "imu0_nodelay": False,
-                "imu0_differential": False,
-                "imu0_relative": False,
-                "imu0_remove_gravitational_acceleration": True,
-                 # OVERRIDE zero covariances from Gazebo
-                "imu0_angular_velocity_covariance": [0.001, 0.0, 0.0,
-                                                     0.0, 0.001, 0.0,
-                                                     0.0, 0.0, 0.001],
-
-                "imu0_linear_acceleration_covariance": [0.01, 0.0, 0.0,
-                                                        0.0, 0.01, 0.0,
-                                                        0.0, 0.0, 0.01],
-
-                "imu0_orientation_covariance": [0.01, 0.0, 0.0,
-                                                0.0, 0.01, 0.0,
-                                                0.0, 0.0, 0.01],
-                
-                }]
-    )
-
     # IMU filter node
     # Filter which fuses angular velocities, accelerations, and 
     # (optionally) magnetic readings from a generic IMU device 
@@ -194,8 +124,9 @@ def generate_launch_description():
                      'publish_tf':False,
                      #'fixed_frame': "camera_link"
                      }],
-        remappings=[('imu/data_raw', '/l515/imu/data')]
+        remappings=[('imu/data_raw', '/l515/imu/raw')]
     )
+    
     # Visual Odometry node
     # This node uses visual odometry to estimate the pose of the robot based on the camera images.
     # It publishes the estimated pose to the /vo_odom topic.
@@ -205,7 +136,7 @@ def generate_launch_description():
         'frame_id': 'ackmann/base_footprint',   # Defaults to "base_footprint" if unspecified
         'odom_frame_id': 'odom',                # Defaults to "odom" if unspecified
         #'guess_frame_id': 'ackmann/base_footprint',
-        'publish_tf': True,
+        'publish_tf': False,
         'use_sim_time': use_sim_time,
         'Odom/Strategy': '0',  # Frame-to-Map visual odometry
         'Vis/MinInliers': '10',  # Minimum inliers for robust matching
@@ -250,13 +181,84 @@ def generate_launch_description():
         remappings=remappings,
         arguments=["--ros-args", "--log-level", 'icp_odometry:=warn'])
 
+
+    # EKF filter node for localization
+    # This node uses the Extended Kalman Filter to fuse odometry and IMU data.
+    # It publishes the estimated pose to the /odom topic.
+    # It is used to provide a more accurate pose estimate for the robot.
+    # It is a part of the robot_localization package.
+    pkg = get_package_share_directory('robot_description')
+    control_params_file = PathJoinSubstitution([pkg, 'config', 'ekf.yaml'])
+    ekf_filter_node = Node(
+            package='robot_localization',
+            executable='ekf_node',
+            name='ekf_filter_node',
+            output='screen',
+            parameters=[#control_params_file,
+                {"frequency": 30.0,
+                 "predict_to_current_time": True,
+                 "history_length": 5.0, 
+                 "use_sim_time": use_sim_time,
+                 "two_d_mode": True,  # Often helpful for ground robots
+                 "publish_tf": True,
+                 "map_frame": "map",                # Defaults to "map" if unspecified
+                 "odom_frame": "odom",           # Defaults to "odom" if unspecified
+                 "base_link_frame": "ackmann/base_footprint",    # Defaults to "base_link" if unspecified
+                 "world_frame": "odom",             # Defaults to the value of odom_frame if unspecified
+                 
+                 # Additional stability parameters
+                "sensor_timeout": 0.2,  # Wait for sensor data
+                "transform_timeout": 0.2,
+                "transform_time_offset": 0.1,
+
+                 "odom0": "/vo_odom",
+                 "odom0_config": [True, True, False,    # x, y, z position
+                                  False, False, True,     # roll, pitch, yaw
+                                  True, True, False,     # x, y, z velocity
+                                  False, False, True,     # roll, pitch, yaw rates
+                                  False, False, False], # x, y, z acceleration
+                 "odom0_queue_size": 10,
+                 "odom0_nodelay": False,
+                 "odom0_differential": False,
+                 "odom0_relative": True,
+                 #"odom0_pose_noise": [0.01, 0.01, 0.01, 0.01, 0.01, 0.01],  # Lower noise for odometry
+                 #"odom0_twist_noise": [0.01, 0.01, 0.01, 0.01, 0.01, 0.01],
+                 
+                 # IMU Configuration  
+                "imu0": "/imu/data", #"/l515/imu/data",
+                "imu0_config": [False, False, False,   # x, y, z position
+                                False,  False,  True,    # roll, pitch, yaw
+                                False, False, False,   # x, y, z velocity
+                                False,  False,  True,    # roll, pitch, yaw rates
+                                False,  False,  False],   # x, y, z acceleration
+                 "imu0_queue_size": 10,
+                 "imu0_nodelay": False,
+                "imu0_differential": False,
+                "imu0_relative": True,
+                "imu0_remove_gravitational_acceleration": True,
+                 # OVERRIDE zero covariances from Gazebo
+                "imu0_angular_velocity_covariance": [0.001, 0.0, 0.0,
+                                                     0.0, 0.001, 0.0,
+                                                     0.0, 0.0, 0.001],
+
+                "imu0_linear_acceleration_covariance": [0.01, 0.0, 0.0,
+                                                        0.0, 0.01, 0.0,
+                                                        0.0, 0.0, 0.01],
+
+                "imu0_orientation_covariance": [0.01, 0.0, 0.0,
+                                                0.0, 0.01, 0.0,
+                                                0.0, 0.0, 0.01],
+                
+                }]
+    )
+
     # SLAM Mode:
     slam = Node(
         condition=UnlessCondition(localization),
         package='rtabmap_slam', executable='rtabmap', output='screen',
         parameters=[rtabmap_parameters, shared_parameters],
         remappings=remappings + [
-            ('odom', "vo_odom"),     # '/odometry/filtered'
+            ('odom', "/odometry/filtered"),     # '/odometry/filtered'
         ],
         arguments=['-d'])
         
@@ -336,7 +338,7 @@ def generate_launch_description():
     ld.add_action(imu_filter_node)
     ld.add_action(visual_odom)
     ld.add_action(icp_odom)
-    #ld.add_action(ekf_filter_node)
+    ld.add_action(ekf_filter_node)
     #ld.add_action(rgbd_to_points)
     #ld.add_action(obstacle_detection)
     ld.add_action(slam)

--- a/robot_description/launch/rtabmap_slam.launch.py
+++ b/robot_description/launch/rtabmap_slam.launch.py
@@ -74,7 +74,7 @@ def generate_launch_description():
         'subscribe_rgbd':True,
         'subscribe_scan':subscribe_scan,
         'use_action_for_goal':True,
-        'odom_sensor_sync': True,
+        'odom_sensor_sync': True,   
         # RTAB-Map's parameters should be strings:
         'Mem/NotLinkedNodesKept':'false',
         'Grid/MaxGroundHeight': '0.1',
@@ -90,8 +90,8 @@ def generate_launch_description():
         'frame_id':'ackmann/base_footprint',
         'use_sim_time':use_sim_time,
         # RTAB-Map's parameters should be strings:
-        'Reg/Strategy':'1',
-        'Reg/Force3DoF':'true',
+        'Reg/Strategy':'1',     # 1: 3D->2D (PnP) for 2D navigation
+        'Reg/Force3DoF':'true', # Force 3 DoF (2D) registration
         'Mem/NotLinkedNodesKept':'false',
         'Icp/PointToPlaneMinComplexity':'0.04' # to be more robust to long corridors with low geometry
     }
@@ -99,6 +99,7 @@ def generate_launch_description():
     remappings=[
         ('scan', scan_topic),
         ('odom', odom_topic),
+        ('imu', '/imu/data'),#'/l515/imu/raw' '/imu/data'
         ('rgb/image', '/ackmann/depth_camera/image'),
         ('rgb/camera_info', '/ackmann/depth_camera/camera_info'),
         ('depth/image', '/ackmann/depth_camera/depth_image'),
@@ -126,6 +127,7 @@ def generate_launch_description():
                 {"frequency": 30.0,
                  "predict_to_current_time": True,
                  "use_sim_time": use_sim_time,
+                 "two_d_mode": True,  # Often helpful for ground robots
                  "publish_tf": True,
                  "map_frame": "map",                # Defaults to "map" if unspecified
                  "odom_frame": "odom",           # Defaults to "odom" if unspecified
@@ -140,26 +142,29 @@ def generate_launch_description():
                  "odom0": "/vo_odom",
                  "odom0_config": [True, True, False,    # x, y, z position
                                   False, False, True,     # roll, pitch, yaw
-                                  False, False, False,     # x, y, z velocity
-                                  False, False, False,     # roll, pitch, yaw rates
+                                  True, True, False,     # x, y, z velocity
+                                  False, False, True,     # roll, pitch, yaw rates
                                   False, False, False], # x, y, z acceleration
                  "odom0_queue_size": 10,
                  "odom0_nodelay": False,
                  "odom0_differential": False,
-                 
-                 # IMU Configuration  
-                "imu0": "/l515/imu/data",
-                "imu0_config": [False, False, False,   # x, y, z position
-                                True,  True,  False,    # roll, pitch, yaw
-                                False, False, False,   # x, y, z velocity
-                                True,  True,  True,    # roll, pitch, yaw rates
-                                True,  True,  True],   # x, y, z acceleration
-                 "imu0_queue_size": 50,
-                 "imu0_nodelay": False,
+                 "odom0_relative": True,
                  "odom0_pose_noise": [0.01, 0.01, 0.01, 0.01, 0.01, 0.01],  # Lower noise for odometry
                  "odom0_twist_noise": [0.01, 0.01, 0.01, 0.01, 0.01, 0.01],
+                 
+                 # IMU Configuration  
+                "imu0": "/imu/data", #"/l515/imu/data",
+                "imu0_config": [False, False, False,   # x, y, z position
+                                False,  False,  True,    # roll, pitch, yaw
+                                False, False, False,   # x, y, z velocity
+                                False,  False,  True,    # roll, pitch, yaw rates
+                                False,  False,  False],   # x, y, z acceleration
+                 "imu0_queue_size": 10,
+                 "imu0_nodelay": False,
+                "imu0_differential": False,
+                "imu0_relative": False,
+                "imu0_remove_gravitational_acceleration": True,
                  # OVERRIDE zero covariances from Gazebo
-                
                 "imu0_angular_velocity_covariance": [0.001, 0.0, 0.0,
                                                      0.0, 0.001, 0.0,
                                                      0.0, 0.0, 0.001],
@@ -172,22 +177,19 @@ def generate_launch_description():
                                                 0.0, 0.01, 0.0,
                                                 0.0, 0.0, 0.01],
                 
-                # Gazebo-specific settings
-                "imu0_differential": False,
-                "imu0_relative": False,
-                "imu0_remove_gravitational_acceleration": True,
-                "two_d_mode": True,  # Often helpful for ground robots
                 }]
     )
 
     # IMU filter node
+    # Filter which fuses angular velocities, accelerations, and 
+    # (optionally) magnetic readings from a generic IMU device 
+    # into an orientation.
     # This node filters the IMU data using the Madgwick filter.
     # It publishes the filtered IMU data to the /imu/data topic.
-    # It is used to provide a more accurate IMU data for the robot.
     imu_filter_node = Node(
         package='imu_filter_madgwick', executable='imu_filter_madgwick_node', output='screen',
         parameters=[{'use_mag': False, 
-                     'world_frame':'nwu', # ned, enu, nwu
+                     'world_frame':'enu', # ned, enu, nwu
                      #'yaw_offset': -1.5708,
                      'publish_tf':False,
                      #'fixed_frame': "camera_link"
@@ -200,8 +202,8 @@ def generate_launch_description():
     # It is used to provide an initial guess for the RTAB-Map SLAM algorithm
     # and to provide a more accurate pose estimate for the robot.
     visual_odom_parameters = {
-        'frame_id': 'ackmann/base_footprint',
-        'odom_frame_id': 'vo_odom',
+        'frame_id': 'ackmann/base_footprint',   # Defaults to "base_footprint" if unspecified
+        'odom_frame_id': 'odom',                # Defaults to "odom" if unspecified
         #'guess_frame_id': 'ackmann/base_footprint',
         'publish_tf': True,
         'use_sim_time': use_sim_time,
@@ -228,9 +230,10 @@ def generate_launch_description():
     # and to provide a more accurate odometry estimate for the robot.
     # It is a part of the RTAB-Map SLAM framework.
     icp_parameters={
-        'odom_frame_id':'icp_odom',
-        'guess_frame_id':'ackmann/odom',
-        'publish_tf': True,  # Add this
+        'odom_frame_id':'odom',
+        #'guess_frame_id':'ackmann/odom',
+        'publish_tf': True,  # Publish TF transforms
+        'use_sim_time': use_sim_time,
         'Icp/CorrespondenceRatio': '0.03',  # Further relax from 0.05
         'Icp/PointToPlaneMinComplexity': '0.01',  # Lower for corridors
         'Icp/MaxCorrespondenceDistance': '0.2',  # Increase from 0.1
@@ -252,7 +255,9 @@ def generate_launch_description():
         condition=UnlessCondition(localization),
         package='rtabmap_slam', executable='rtabmap', output='screen',
         parameters=[rtabmap_parameters, shared_parameters],
-        remappings=remappings,
+        remappings=remappings + [
+            ('odom', "vo_odom"),     # '/odometry/filtered'
+        ],
         arguments=['-d'])
         
     # Localization mode:
@@ -328,10 +333,10 @@ def generate_launch_description():
     ld = LaunchDescription(ARGUMENTS)
     ld.add_action(rgbd_sync)
     ld.add_action(depth_to_scan)
-    #ld.add_action(imu_filter_node)
+    ld.add_action(imu_filter_node)
     ld.add_action(visual_odom)
     ld.add_action(icp_odom)
-    ld.add_action(ekf_filter_node)
+    #ld.add_action(ekf_filter_node)
     #ld.add_action(rgbd_to_points)
     #ld.add_action(obstacle_detection)
     ld.add_action(slam)

--- a/robot_description/urdf/donkey_sensors.urdf
+++ b/robot_description/urdf/donkey_sensors.urdf
@@ -449,7 +449,7 @@
       <ros> 
         <namespace></namespace> 
         <remapping>ackermann_steering_controller/reference_unstamped:=cmd_vel</remapping> 
-        <!-- <remapping>ackermann_steering_controller/odometry:=odom</remapping>  -->
+        <!-- <remapping>ackermann_steering_controller/odometry:=/wheel/odom</remapping>  -->
         <!-- <remapping>ackermann_steering_controller/tf_odometry:=tf</remapping>  -->
       </ros> 
     </plugin>

--- a/robot_description/urdf/realsense/_l515.urdf.xacro
+++ b/robot_description/urdf/realsense/_l515.urdf.xacro
@@ -192,6 +192,7 @@ aluminum peripherial evaluation case.
 
       <joint name="${name}_imu_optical_joint" type="fixed">
         <origin xyz = "${l515_cam_color_to_imu_px} ${l515_cam_color_to_imu_py} ${l515_cam_color_to_imu_pz}" rpy = "${-M_PI/2} 0 ${-M_PI/2}" />
+        <!-- <origin xyz = "${l515_cam_color_to_imu_px} ${l515_cam_color_to_imu_py} ${l515_cam_color_to_imu_pz}" rpy = "0 0 0" /> -->
         <parent link="${name}_link" />
         <child link="${name}_imu_optical_frame" />
       </joint>


### PR DESCRIPTION
This PR includes VIO integration to the whole slam framework based rtabmap. EKF is used to fuse vision odometry and imu to get better/smooth odometry estimation. Such method can be extend to fuse multiple sensor data, e.g. wheel odometry, vision odometry, icp odometry, imu and GPS.

1. add imu from gazebo
2. EKF fusion of imu+vo